### PR TITLE
Switch from NewtonSoft.Json to System.Text.Json

### DIFF
--- a/Bitstream.Net/Bitstream.Net.csproj
+++ b/Bitstream.Net/Bitstream.Net.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net8.0</TargetFrameworks>
+    <LangVersion>12</LangVersion>  
     <Version>1.0.20</Version>
     <RootNamespace>Bitstream.Net</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
@@ -12,10 +13,6 @@
 
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Bitstream.Net/Serializtion/JsonSerializationContext.cs
+++ b/Bitstream.Net/Serializtion/JsonSerializationContext.cs
@@ -1,0 +1,10 @@
+﻿using System.Text.Json.Serialization;
+
+namespace Bitstream.Net.Serializtion;
+
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default)]
+
+[JsonSerializable(typeof(BitstreamPayload))]
+[JsonSerializable(typeof(BitstreamPayloadRequest))]
+[JsonSerializable(typeof(BitstreamPayloadResponse))]
+internal sealed partial class JsonSerializationContext : JsonSerializerContext;

--- a/Bitstream.Net/Serializtion/JsonSerializerOptionsFactory.cs
+++ b/Bitstream.Net/Serializtion/JsonSerializerOptionsFactory.cs
@@ -1,0 +1,37 @@
+﻿using System.Text.Json;
+
+namespace Bitstream.Net.Serializtion;
+
+/// <summary>
+/// Represents a factory for <see cref="JsonSerializerOptions"/>
+/// </summary>
+/// <remarks>
+/// Originally copied over from <see
+/// href="https://github.com/akamsteeg/AtleX.HaveIBeenPwned/blob/757ff49e9314f1c3480d8011ec49bbc7b839c564/src/AtleX.HaveIBeenPwned/Serialization/Json/JsonSerializerOptionsFactory.cs"/>
+/// and adapted to this project
+/// </remarks>
+internal static class JsonSerializerOptionsFactory
+{
+    /// <summary>
+    /// Creates a new instance of <see cref="JsonSerializerOptions"/>
+    /// </summary>
+    /// <returns>
+    /// The created <see cref="JsonSerializerOptions"/>
+    /// </returns>
+    public static JsonSerializerOptions Create()
+    {
+        var result = new JsonSerializerOptions();
+
+        result.WriteIndented = true;
+
+#if NET8_0_OR_GREATER
+        result.TypeInfoResolverChain.Add(new JsonSerializationContext());
+
+        result.MakeReadOnly(); // Guard against modifications
+#elif NET6_0_OR_GREATER
+        result.AddContext<JsonSerializationContext>();
+#endif
+
+        return result;
+    }
+}


### PR DESCRIPTION
By using System.Text.Json there's one less third party dependency and System.Text.Json is measurably faster than NewtonSoft.Json. Even more so when source generated code is used for (de)serialization instead of reflection-based code, so that is also implemented.

This also makes the JSON part largely AOT compatible. However, since the rest of the library requires some work to be compatible, not all parts for making the serialization fully AOT compatible are implemented.